### PR TITLE
 FIX: asset dispatch: clean asset display

### DIFF
--- a/langs/en_US/dispatch.lang
+++ b/langs/en_US/dispatch.lang
@@ -17,3 +17,4 @@ CalculateFollowingSerialNumbers=Calculate the others
 DISPATCH_CAN_LINK_ASSET_TO_OBJECT_IN_ANY_STATUS=Enable linking/unlinking assets to objects (order, contrat, etc.) regardless of their status
 
 NoAssetCreated=No asset created in database
+AssetAlreadyLinked=Equipement déjà lié à cet import=Asset already linked to this dispatch

--- a/langs/en_US/dispatch.lang
+++ b/langs/en_US/dispatch.lang
@@ -15,3 +15,5 @@ DISPATCH_CREATE_NUMSERIE_ON_RECEPTION_FROM_FIRST_INPUT=Enable asset creation wit
 CalculateFollowingSerialNumbers=Calculate the others
 
 DISPATCH_CAN_LINK_ASSET_TO_OBJECT_IN_ANY_STATUS=Enable linking/unlinking assets to objects (order, contrat, etc.) regardless of their status
+
+NoAssetCreated=No asset created in database

--- a/langs/fr_FR/dispatch.lang
+++ b/langs/fr_FR/dispatch.lang
@@ -38,3 +38,5 @@ DISPATCH_CREATE_NUMSERIE_ON_RECEPTION_FROM_FIRST_INPUT=Permettre de créer les �
 CalculateFollowingSerialNumbers=Calculer les suivants
 
 DISPATCH_CAN_LINK_ASSET_TO_OBJECT_IN_ANY_STATUS=Permettre de lier/délier des équipements à des objets (commande, contrat, etc.) quel que soit leur statut
+
+NoAssetCreated=Aucun équipement créé en base

--- a/langs/fr_FR/dispatch.lang
+++ b/langs/fr_FR/dispatch.lang
@@ -40,3 +40,4 @@ CalculateFollowingSerialNumbers=Calculer les suivants
 DISPATCH_CAN_LINK_ASSET_TO_OBJECT_IN_ANY_STATUS=Permettre de lier/délier des équipements à des objets (commande, contrat, etc.) quel que soit leur statut
 
 NoAssetCreated=Aucun équipement créé en base
+AssetAlreadyLinked=Equipement déjà lié à cette ventilation

--- a/reception.php
+++ b/reception.php
@@ -1175,7 +1175,7 @@ global $langs, $db, $conf;
 							if($commande->statut >= 5 || $commande->statut<=2) {
 								echo $asset->getNomUrl(1);
 							} else {
-								echo $form->texte('','TLine['.$k.'][numserie]', $line['numserie'], 30).' '.img_picto($langs->trans('SerialNumberNeeded'), 'warning.png');
+								echo $form->texte('','TLine['.$k.'][numserie]', $line['numserie'], 30).' '.img_picto($langs->trans('AssetAlreadyLinked'), 'warning.png');
 							}
 						}
 						else {

--- a/reception.php
+++ b/reception.php
@@ -1165,18 +1165,21 @@ global $langs, $db, $conf;
 				?><tr class="dispatchAssetLine" id="dispatchAssetLine<?php print $k; ?>" data-fk-product="<?php print $prod->id; ?>">
 					<td><?php echo $prod->getNomUrl(1).$form->hidden('TLine['.$k.'][fk_product]', $prod->id).$form->hidden('TLine['.$k.'][ref]', $prod->ref)." - ".$prod->label; ?></td>
 					<td><?php
-						echo $form->texte('','TLine['.$k.'][numserie]', $line['numserie'], 30) ;
 						$asset=new TAsset;
 
 						if(empty($line['numserie'])) {
-							echo img_picto($langs->trans('SerialNumberNeeded'), 'warning.png');
+							echo $form->texte('','TLine['.$k.'][numserie]', $line['numserie'], 30).' '.img_picto($langs->trans('SerialNumberNeeded'), 'warning.png');
 							$warning_asset = true;
 						}
 						else if($asset->loadReference($PDOdb, $line['numserie'])) {
-							echo '<a href="'.dol_buildpath('/asset/fiche.php?id='.$asset->getId(),1).'">' .img_picto('Equipement lié à cet import', 'info.png'). '</a>';
+							if($commande->statut >= 5 || $commande->statut<=2) {
+								echo $asset->getNomUrl(1);
+							} else {
+								echo $form->texte('','TLine['.$k.'][numserie]', $line['numserie'], 30).' '.img_picto($langs->trans('SerialNumberNeeded'), 'warning.png');
+							}
 						}
 						else {
-							echo img_picto('Aucun équipement créé en Base', 'warning.png');
+							echo $form->texte('','TLine['.$k.'][numserie]', $line['numserie'], 30).' '.img_picto($langs->trans('NoAssetCreated'), 'info.png');
 							$warning_asset = true;
 						}
 						echo $form->hidden('TLine['.$k.'][commande_fournisseurdet_asset]', $line['commande_fournisseurdet_asset'], 30)


### PR DESCRIPTION
- Si la ventilation est complète, on n'affiche que le lien vers l'équipement
- Le warning qui s'affiche quand l'équipement n'a pas encore été créé devient juste une infobulle
- L'infobulle affichée si l'équipement existe et est déjà lié devient un warning