### PR TITLE
New cumul on existing asset

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -1,26 +1,26 @@
 <?php
-	
+
 	require '../config.php';
 	//require('../lib/asset.lib.php');
 	require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
-	
+
 	global $user,$langs,$db,$const,$conf;
-	
+
 	$langs->load('dispatch@dispatch');
 	$langs->load('admin');
-	
+
 	if (!($user->admin)) accessforbidden();
-	
+
 	$action=__get('action','');
 
 	if($action=='save') {
-		
+
 		foreach($_REQUEST['TDispatch'] as $name=>$param) {
-			
+
 			dolibarr_set_const($db, $name, $param, 'chaine', 0, '', $conf->entity);
-			
+
 		}
-		
+
 		setEventMessage("Configuration enregistrée");
 	}
 
@@ -28,19 +28,19 @@
 		$const = GETPOST('const', 'alpha');
 		dolibarr_set_const($db,$const,GETPOST($const,'alpha'),'chaine',0,'',$conf->entity);
 	}
-	
+
 
 	llxHeader('', $langs->trans("DispatchSetupTitle"), '');
-	
+
 	$linkback = '<a href="'.DOL_URL_ROOT.'/admin/modules.php">'.$langs->trans("BackToModuleList").'</a>';
 	print load_fiche_titre( $langs->trans("DispatchSetup"), $linkback );
-	
+
 	print '<table class="noborder" width="100%">';
 	print '<tr class="liste_titre">';
 	print '<td>'.$langs->trans("Parameters").'</td>'."\n";
 	print '<td align="center" width="20">&nbsp;</td>';
 	print '<td align="center" width="100">'.$langs->trans("Value").'</td>'."\n";
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("UseImportFile").'</td>';
@@ -48,7 +48,7 @@
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('DISPATCH_USE_IMPORT_FILE');
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("DispatchRecepAutoQuantity").'</td>';
@@ -56,7 +56,7 @@
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('DISPATCH_RECEP_AUTO_QUANTITY');
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("DISPATCH_HIDE_DLUO_PDF").'</td>';
@@ -64,15 +64,15 @@
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('DISPATCH_HIDE_DLUO_PDF');
 	print '</td></tr>';
-	
+
 	$form=new TFormCore;
-	
+
 	print '<tr class="liste_titre">';
 	print '<td>'.$langs->trans("SUPPLIER_ORDER_RECEPTION").'</td>'."\n";
 	print '<td align="center" width="20">&nbsp;</td>';
 	print '<td align="center" width="100">'.$langs->trans("Value").'</td>'."\n";
 	print '<tr>';
-	
+
 	// Champ supplémentaire contenant le code comptable produit pour les ventes CEE
 	$var=! $var;
 	$form = new TFormCore($_SERVER["PHP_SELF"],'const_dluo_by_default');
@@ -86,7 +86,7 @@
 	print '<input type="submit" class="button" value="'.$langs->trans("Modify").'" />';
 	print "</td></tr>\n";
 	$form->end();
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("DISPATCH_UPDATE_ORDER_PRICE_ON_RECEPTION").'</td>';
@@ -94,7 +94,7 @@
 	print '<td align="center" width="300">';
 	print ajax_constantonoff("DISPATCH_UPDATE_ORDER_PRICE_ON_RECEPTION");
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("DISPATCH_CREATE_SUPPLIER_PRICE").'</td>';
@@ -103,7 +103,7 @@
 	print ajax_constantonoff("DISPATCH_CREATE_SUPPLIER_PRICE");
 	print '</td></tr>';
 
-	
+
         $var=!$var;
         print '<tr '.$bc[$var].'>';
         print '<td>'.$langs->trans("DISPATCH_USE_ONLY_UNIT_ASSET_RECEPTION").'</td>';
@@ -120,7 +120,7 @@
         print ajax_constantonoff("DISPATCH_SHOW_UNIT_RECEPTION");
         print '</td></tr>';
 
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("DISPATCH_CREATE_NUMSERIE_ON_RECEPTION_IF_LOT").'</td>';
@@ -193,7 +193,15 @@ print '<td align="center" width="300">';
 print ajax_constantonoff('DISPATCH_STOCK_MOVEMENT_BY_ASSET');
 print '</td></tr>';
 
-	
+$var=!$var;
+print '<tr '.$bc[$var].'>';
+print '<td>'.$langs->trans('DISPATCH_ALLOW_DISPATCHING_EXISTING_ASSET').'</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="center" width="300">';
+print ajax_constantonoff('DISPATCH_ALLOW_DISPATCHING_EXISTING_ASSET');
+print '</td></tr>';
+
+
 	print "</table>";
 
 	dol_fiche_end();

--- a/class/dispatchdetail.class.php
+++ b/class/dispatchdetail.class.php
@@ -18,28 +18,28 @@ class TDispatchDetail extends TObjetStd {
 
 	function __construct() {
 		global $langs;
-		
+
 		parent::set_table(MAIN_DB_PREFIX.'expeditiondet_asset');
 		parent::add_champs('fk_expeditiondet,fk_asset','type=entier;index;');
 		parent::add_champs('rang,is_prepared','type=entier;');
 		parent::add_champs('lot_number,carton,numerosuivi','type=chaine;');
 		parent::add_champs('weight, weight_reel, tare','type=float;');
 		parent::add_champs('weight_unit, weight_reel_unit, tare_unit','type=entier;');
-		
+
 		parent::_init_vars();
 		parent::start();
-		
+
 		$this->lines = array();
 		$this->nbLines = 0;
 	}
-	
+
 	//Charges les lignes de flacon associé à la ligne d'expédition passé en paramètre
 	function loadLines(&$PDOdb, $id_expeditionLine){
-		
+
 		$sql = "SELECT rowid FROM ".$this->get_table()." WHERE fk_expeditiondet = ".$id_expeditionLine." ORDER BY rang";
-		
+
 		$TIdExpedet = TRequeteCore::_get_id_by_sql($PDOdb, $sql);
-		
+
 		foreach($TIdExpedet as $idexpedet){
 			$dispatchdetail_temp = new TDispatchDetail;
 			$dispatchdetail_temp->load($PDOdb, $idexpedet);
@@ -47,7 +47,7 @@ class TDispatchDetail extends TObjetStd {
 			$this->nbLines = $this->nbLines + 1;
 		}
 	}
-	
+
 	function getPoidsExpedie(&$PDOdb,$id_expeditionLine,$product){
 		$sql = "SELECT SUM(eda.weight) as Total, eda.weight_reel_unit as Unite
 				FROM ".MAIN_DB_PREFIX."expeditiondet_asset as eda
@@ -55,13 +55,13 @@ class TDispatchDetail extends TObjetStd {
 					LEFT JOIN ".MAIN_DB_PREFIX."commandedet as c ON (c.rowid = ed.fk_origin_line)
 				WHERE ed.fk_origin_line IN (SELECT fk_origin_line FROM ".MAIN_DB_PREFIX."expeditiondet WHERE rowid = ".$id_expeditionLine.")
 				GROUP BY Unite";
-		
+
 		$total = 0;
 		$PDOdb->Execute($sql);
 		while($PDOdb->Get_line()){
 			$total += $PDOdb->Get_field('Total') * pow(10,$PDOdb->Get_field('Unite'));
 		}
-		
+
 		return $total * pow(10,-$product->weight_units) ;
 	}
 }
@@ -69,15 +69,15 @@ class TDispatchDetail extends TObjetStd {
 class TRecepDetail extends TObjetStd {
 	function __construct() {
 		global $langs;
-		
+
 		parent::set_table(MAIN_DB_PREFIX.'commande_fournisseurdet_asset');
 		parent::add_champs('fk_commandedet,fk_product,fk_warehouse','type=entier;index;');
 		parent::add_champs('rang','type=entier;');
 		parent::add_champs('lot_number,carton,numerosuivi,imei,firmware,serial_number','type=chaine;');
 		parent::add_champs('weight, weight_reel, tare','type=float;');
 		parent::add_champs('dluo','type=date;');
-		parent::add_champs('weight_unit, weight_reel_unit, tare_unit','type=entier;');
-		
+		parent::add_champs('weight_unit, weight_reel_unit, tare_unit, already_dispatch','type=entier;');
+
 		parent::_init_vars();
 		parent::start();
 	}

--- a/langs/fr_FR/dispatch.lang
+++ b/langs/fr_FR/dispatch.lang
@@ -84,6 +84,7 @@ BDRClose=cloture
 DISPATCH_RESET_ASSET_WAREHOUSE_ON_SHIPMENT=Retirer l'entrepot de l'équipement à la validation de l'expédition
 DISPATCH_SKIP_SERVICES=Ignorer les lignes de type service
 DISPATCH_STOCK_MOVEMENT_BY_ASSET=Lorsqu'il y a plusieurs équipements pour le même produit lors d'une réception, faire en sorte qu'il y ait un mouvement de stock par équipement, plutôt qu'un mouvement de stock global contenant tous les équipements
+DISPATCH_ALLOW_DISPATCHING_EXISTING_ASSET=Permettre de réceptionner plusieurs fois un équipement existant
 
 # Expedition Card
 colDispatch=N° de série / lot
@@ -99,3 +100,4 @@ DispatchSerialNumber=Numéro de série
 DispatchBatchNumber=Numéro de Lot
 DispatchDateReception=Date de réception
 DispatchMsgAssetGen=Equipements créés / produits ventilés
+ProductHasToBeSerialize=Le produit %s doit être sérialisé

--- a/reception.php
+++ b/reception.php
@@ -167,6 +167,9 @@
 
 		foreach($TImport as $k=>&$line) {
 			$asset =new TAsset;
+			$receptDetailLine = new TRecepDetail;
+			$receptDetailLine->load($PDOdb, $line['commande_fournisseurdet_asset']);
+			if(!empty($receptDetailLine->already_dispatch)) continue;
 
 			if(!empty($conf->global->DISPATCH_CREATE_NUMSERIE_ON_RECEPTION_IF_LOT) && empty($line['numserie']) && !empty($line['lot_number'])) {
 
@@ -272,9 +275,9 @@
 				$stock = new TAssetStock;
 				$stock->mouvement_stock($PDOdb, $user, $asset->getId(), $asset->contenancereel_value, $langs->trans("DispatchSupplierOrder",$commandefourn->ref), $commandefourn->id);
 	*/
-				$receptDetailLine = new TRecepDetail;
-				$receptDetailLine->load($PDOdb, $line['commande_fournisseurdet_asset']);
+
 				if($asset->serial_number != $line['numserie'])	$receptDetailLine->numserie = $receptDetailLine->serial_number = $asset->serial_number;
+				$receptDetailLine->already_dispatch = 1;
 				$receptDetailLine->save($PDOdb);
 
 				//Compteur pour chaque produit : 1 équipement = 1 quantité de produit ventilé
@@ -340,42 +343,33 @@
 		$TOrderLine=GETPOST('TOrderLine');
 
 		if(!empty($TOrderLine)) {
-			$TQtyDispatchTmp = $TQtyDispatch;
 			foreach($TOrderLine as &$line) {
-				if($line['qty'] > 0) {
-					$checkingProduct = new Product($db);
-					$checkingProduct->fetch($line['fk_product']);
-					if($checkingProduct->array_options['options_type_asset'] > 0) { // Pour éviter les ventilations sur les produits sérialisés
-						setEventMessage($langs->trans('ProductHasToBeSerialize',$checkingProduct->ref),'errors');
-						$TProdVentil = array();
-						$TQtyDispatch = $TQtyDispatchTmp;
-						break;
+				$checkingProduct = new Product($db);
+				$checkingProduct->fetch($line['fk_product']);
+				if($checkingProduct->array_options['options_type_asset'] == 0) { //On ne fait des mouvements de stock que pour les produits non sérialisables
+
+					if(!isset($TProdVentil[$line['fk_product']])) $TProdVentil[$line['fk_product']]['qty'] = 0;
+					$TProdVentil[$line['fk_product']]['price'] = $line['subprice'];
+					// Si serialisé on ne prend pas la quantité déjà calculé plus haut.
+					if(empty($line['serialized'])) $TProdVentil[$line['fk_product']]['qty'] += $line['qty'];
+
+					if(!empty($line['entrepot']) && $line['entrepot'] > 0) {
+						$TProdVentil[$line['fk_product']]['entrepot'] = $line['entrepot'];
 					}
-				}
 
-				if(!isset($TProdVentil[$line['fk_product']])) $TProdVentil[$line['fk_product']]['qty'] = 0;
-				$TProdVentil[$line['fk_product']]['price'] = $line['subprice'];
-				// Si serialisé on ne prend pas la quantité déjà calculé plus haut.
-				if(empty($line['serialized'] )) $TProdVentil[$line['fk_product']]['qty']+=$line['qty'];
+					if($conf->global->DISPATCH_UPDATE_ORDER_PRICE_ON_RECEPTION) {
+						$TProdVentil[$line['fk_product']]['supplier_price'] = $line['supplier_price'];
+					}
 
-				if(!empty($line['entrepot']) && $line['entrepot']>0) {
-					$TProdVentil[$line['fk_product']]['entrepot'] = $line['entrepot'];
-				}
+					if($conf->global->DISPATCH_CREATE_SUPPLIER_PRICE) {
+						$TProdVentil[$line['fk_product']]['supplier_qty'] = $line['supplier_qty'];
+						$TProdVentil[$line['fk_product']]['generate_supplier_tarif'] = $line['generate_supplier_tarif'];
+					}
 
-				if($conf->global->DISPATCH_UPDATE_ORDER_PRICE_ON_RECEPTION)
-				{
-					$TProdVentil[$line['fk_product']]['supplier_price']=$line['supplier_price'];
-				}
-
-				if($conf->global->DISPATCH_CREATE_SUPPLIER_PRICE)
-				{
-					$TProdVentil[$line['fk_product']]['supplier_qty']=$line['supplier_qty'];
-					$TProdVentil[$line['fk_product']]['generate_supplier_tarif']=$line['generate_supplier_tarif'];
-				}
-
-				//Build array with quantity wished by product
-				if (array_key_exists('fk_product', $line) && !empty($line['fk_product']) && !array_key_exists($line['fk_product'], $TQtyDispatch)) {
-					$TQtyDispatch[$line['fk_product']]+=$line['qty'];
+					//Build array with quantity wished by product
+					if(array_key_exists('fk_product', $line) && !empty($line['fk_product']) && !array_key_exists($line['fk_product'], $TQtyDispatch)) {
+						$TQtyDispatch[$line['fk_product']] += $line['qty'];
+					}
 				}
 
 			}
@@ -493,6 +487,7 @@
         if(method_exists($commandefourn, 'log')) $commandefourn->log($user, $status, time()); // removed in 4.0
 
         setEventMessage($langs->transnoentities('DispatchMsgAssetGen'));
+		$TImport = _loadDetail($PDOdb,$commandefourn);
 
 	}
 //var_dump($TImport);exit;
@@ -506,7 +501,7 @@ function _loadDetail(&$PDOdb,&$commandefourn){
 
     foreach($commandefourn->lines as $line){
 
-        $sql = "SELECT ca.rowid as idline,ca.serial_number,p.ref,p.rowid, ca.fk_commandedet, ca.fk_warehouse, ca.imei, ca.firmware,ca.lot_number,ca.weight_reel,ca.weight_reel_unit, ca.dluo
+        $sql = "SELECT ca.rowid as idline,ca.serial_number,p.ref,p.rowid, ca.fk_commandedet, ca.fk_warehouse, ca.imei, ca.firmware,ca.lot_number,ca.weight_reel,ca.weight_reel_unit, ca.dluo, ca.already_dispatch
 			FROM ".MAIN_DB_PREFIX."commande_fournisseurdet_asset as ca
 				LEFT JOIN ".MAIN_DB_PREFIX."product as p ON (p.rowid = ca.fk_product)
 			WHERE ca.fk_commandedet = ".$line->id."
@@ -526,6 +521,7 @@ function _loadDetail(&$PDOdb,&$commandefourn){
                 ,'fk_product'=>$PDOdb->Get_field('rowid')
                 ,'fk_warehouse'=>$PDOdb->Get_field('fk_warehouse')
                 ,'dluo'=>$PDOdb->Get_field('dluo')
+                ,'already_dispatch'=>$PDOdb->Get_field('already_dispatch')
                 ,'commande_fournisseurdet_asset'=>$PDOdb->Get_field('idline')
             );
         }
@@ -570,27 +566,27 @@ function _addCommandedetLine(&$PDOdb,&$TImport,&$commandefourn,$refproduit,$nums
 
     $keys = array_keys($TImport);
     $rang = $keys[count($keys)-1];
+    if(!$lineFound || ($lineFound && empty($recepdetail->already_dispatch))) {
+		$recepdetail->fk_commandedet = $fk_line;
+		$recepdetail->fk_product = $prodAsset->id;
+		$recepdetail->rang = $rang + 1;
+		$recepdetail->set_date('dluo', ($dluo) ? $dluo : date('Y-m-d H:i:s'));
+		$recepdetail->lot_number = $lot_number;
+		$recepdetail->weight_reel = $quantity;
+		$recepdetail->weight = $quantity;
+		$recepdetail->weight_unit = $quantity_unit;
+		$recepdetail->weight_reel_unit = $quantity_unit;
+		$recepdetail->serial_number = $numserie;
+		$recepdetail->imei = $imei;
+		$recepdetail->firmware = $firmware;
+		$recepdetail->fk_warehouse = $entrepot;
+		/*$recepdetail->weight = 1;
+		 $recepdetail->weight_reel = 1;
+		 $recepdetail->weight_unit = 0;
+		 $recepdetail->weight_reel_unit = 0;*/
 
-    $recepdetail->fk_commandedet = $fk_line;
-    $recepdetail->fk_product = $prodAsset->id;
-    $recepdetail->rang = $rang + 1;
-    $recepdetail->set_date('dluo', ($dluo) ? $dluo : date('Y-m-d H:i:s'));
-    $recepdetail->lot_number = $lot_number;
-    $recepdetail->weight_reel = $quantity;
-    $recepdetail->weight = $quantity;
-    $recepdetail->weight_unit = $quantity_unit;
-    $recepdetail->weight_reel_unit = $quantity_unit;
-    $recepdetail->serial_number = $numserie;
-    $recepdetail->imei = $imei;
-    $recepdetail->firmware = $firmware;
-    $recepdetail->fk_warehouse = $entrepot;
-    /*$recepdetail->weight = 1;
-     $recepdetail->weight_reel = 1;
-     $recepdetail->weight_unit = 0;
-     $recepdetail->weight_reel_unit = 0;*/
-
-    $recepdetail->save($PDOdb);
-
+		$recepdetail->save($PDOdb);
+	}
     $currentLine = array(
         'ref'=>$prodAsset->ref
         ,'numserie'=>$numserie
@@ -1153,8 +1149,6 @@ global $langs, $db, $conf, $hookmanager;
 	$formDoli =	new Form($db);
 	$formproduct=new FormProduct($db);
 
-	if($commande->statut >= 5 || $commande->statut<=2) $form->type_aff = "view";
-
 	if ($commande->statut <= 2 || $commande->statut >= 6)
 	{
 		print $langs->trans("OrderStatusNotReadyToDispatch");
@@ -1213,6 +1207,8 @@ global $langs, $db, $conf, $hookmanager;
 
 		if(is_array($TImport)){
 			foreach ($TImport as $k=>$line) {
+				if($commande->statut >= 5 || $commande->statut<=2 || !empty($line['already_dispatch'])) $form->type_aff = "view";
+				else $form->type_aff = "edit";
 				if($prod->id==0 || $line['ref']!= $prod->ref) {
 					if(empty($line['fk_product']) === false) {
 						$prod->fetch($line['fk_product']);
@@ -1233,7 +1229,7 @@ global $langs, $db, $conf, $hookmanager;
 							$warning_asset = true;
 						}
 						else if($asset->loadReference($PDOdb, $line['numserie'], $line['fk_product'])) {
-							if($commande->statut >= 5 || $commande->statut<=2) {
+							if($commande->statut >= 5 || $commande->statut<=2 || !empty($line['already_dispatch'])) {
 								echo $asset->getNomUrl(1);
 							} else {
 								if(!empty($conf->global->DISPATCH_ALLOW_DISPATCHING_EXISTING_ASSET)) {
@@ -1258,12 +1254,12 @@ global $langs, $db, $conf, $hookmanager;
 
 						if (count($formproduct->cache_warehouses)>1)
 						{
-							if($commande->statut >= 5 || $commande->statut<=2) print $formproduct->selectWarehouses($line['fk_warehouse'], 'TLine['.$k.'][entrepot]','',1,1,$prod->id,'',0,1);
+							if($commande->statut >= 5 || $commande->statut<=2 || !empty($line['already_dispatch'])) print $formproduct->selectWarehouses($line['fk_warehouse'], 'TLine['.$k.'][entrepot]','',1,1,$prod->id,'',0,1);
 							else print $formproduct->selectWarehouses($line['fk_warehouse'], 'TLine['.$k.'][entrepot]','',1,0,$prod->id,'',0,1);
 						}
 						elseif  (count($formproduct->cache_warehouses)==1)
 						{
-							if($commande->statut >= 5 || $commande->statut<=2) print $formproduct->selectWarehouses($line['fk_warehouse'], 'TLine['.$k.'][entrepot]','',0,1,$prod->id,'',0,1);
+							if($commande->statut >= 5 || $commande->statut<=2 || !empty($line['already_dispatch'])) print $formproduct->selectWarehouses($line['fk_warehouse'], 'TLine['.$k.'][entrepot]','',0,1,$prod->id,'',0,1);
 							else print $formproduct->selectWarehouses($line['fk_warehouse'], 'TLine['.$k.'][entrepot]','',0,0,$prod->id,'',0,1);
 						}
 						else
@@ -1281,7 +1277,7 @@ global $langs, $db, $conf, $hookmanager;
 						<td><?php echo $form->texte('','TLine['.$k.'][quantity]', $line['quantity'], 10);   ?></td><?php
 
 						if(!empty($conf->global->DISPATCH_SHOW_UNIT_RECEPTION)) {
-							?> <td><?php if($commande->statut < 5) {
+							?> <td><?php if($commande->statut < 5 && empty($line['already_dispatch'])) {
 								$formproduct->select_measuring_units('TLine['.$k.'][quantity_unit]','weight',$line['quantity_unit']);
 							} else echo measuring_units_string($line['quantity_unit'],'weight');?></td><?php
 						}
@@ -1315,7 +1311,7 @@ global $langs, $db, $conf, $hookmanager;
 		}
 
 		if($commande->statut < 5 && $commande->statut>2){
-
+			$form->type_aff = "edit";
 			$TProducts = array($langs->transnoentities('DispatchSelectProduct'));
 			foreach($commande->lines as $line){
 				if($line->fk_product) $TProducts[$line->fk_product] = $line->product_ref." - ".$line->product_label;

--- a/reception.php
+++ b/reception.php
@@ -1178,7 +1178,7 @@ global $langs, $db, $conf, $hookmanager;
 					}).done(function(data) {
 						let parentTd = $("select[name='TLine[-1][entrepot]']").closest('td');
 						$("select[name='TLine[-1][entrepot]']").remove();
-						parentTd.append(data)
+						parentTd.append(data);
 					});
 				}
 			});

--- a/reception.php
+++ b/reception.php
@@ -1164,6 +1164,24 @@ global $langs, $db, $conf, $hookmanager;
 			$("#dispatchAsset").change(function() {
 				$("#actionVentilation").addClass("error").html("<?php echo $langs->trans('SaveBeforeVentil') ?>");
 			});
+			$("#new_line_fk_product").change(function() {
+				let fk_product = $(this).val();
+				if(fk_product > 0) {
+					$.ajax({
+						url:"script/interface.php"
+						,dataType:"html"
+						,data:{
+							'fk_product': fk_product
+							,'get':'select-warehouse-default'
+						}
+
+					}).done(function(data) {
+						let parentTd = $("select[name='TLine[-1][entrepot]']").closest('td');
+						$("select[name='TLine[-1][entrepot]']").remove();
+						parentTd.append(data)
+					});
+				}
+			});
 		});
 	</script>
 	<table width="100%" class="noborder" id="dispatchAsset">

--- a/reception.php
+++ b/reception.php
@@ -1279,7 +1279,7 @@ global $langs, $db, $conf, $hookmanager;
 						if(!empty($conf->global->DISPATCH_SHOW_UNIT_RECEPTION)) {
 							?> <td><?php if($commande->statut < 5 && empty($line['already_dispatch'])) {
 								$formproduct->select_measuring_units('TLine['.$k.'][quantity_unit]','weight',$line['quantity_unit']);
-							} else echo measuring_units_string($line['quantity_unit'],'weight');?></td><?php
+							} else echo measuring_units_string(0,'weight',$line['quantity_unit']);?></td><?php
 						}
 					}
 					else{

--- a/script/interface.php
+++ b/script/interface.php
@@ -8,6 +8,8 @@ require('../config.php');
 //dol_include_once('/' . ATM_ASSET_NAME . '/config.php');
 dol_include_once('/' . ATM_ASSET_NAME . '/lib/asset.lib.php');
 dol_include_once('/' . ATM_ASSET_NAME . '/class/asset.class.php');
+dol_include_once('/product/class/product.class.php');
+dol_include_once('/product/class/html.formproduct.class.php');
 
 //Interface qui renvoie les emprunts de ressources d'un utilisateur
 $PDOdb=new TPDOdb;
@@ -24,6 +26,10 @@ _put($PDOdb, $put);
 function _get(&$PDOdb, $get) {
 
 	switch ($get) {
+		case 'select-warehouse-default':
+
+			print _getSelectWarehouseWithDefaultSelected(GETPOST('fk_product'));
+			break;
 		case 'serial_number':
 
 			__out(_serial_number($PDOdb, GETPOST('term')),'json');
@@ -52,6 +58,14 @@ function _put(TPDOdb &$PDOdb, $put)
 			__out(_set_all_lines_is_prepared($PDOdb, GETPOST('fk_expedition', 'int'), GETPOST('is_prepared', 'int')), 'json');
 			break;
 	}
+}
+
+function _getSelectWarehouseWithDefaultSelected($fk_product) {
+	global $db;
+	$formproduct = new FormProduct($db);
+	$prod = new Product($db);
+	$prod->fetch($fk_product);
+	return $formproduct->selectWarehouses($prod->fk_default_warehouse,'TLine[-1][entrepot]','',1,0,$prod->id,'',0,1);
 }
 
 function _serial_number(&$PDOdb, $sn) {


### PR DESCRIPTION
Nouvelle conf permettant de pouvoir réceptionner plusieurs fois un même numéro de série : 
- Ajout d'un champ en BDD permett
- Modification de la contenance reel effective sur l'équipement
- Mouvement de stock équipement 
- Mouvement de stock standard dolibarr 
- fix le soucis qui permettait de dispatch des produits sérialisables sans l'avoir sérialisé
- Ajout d'une tooltip avec le getnomurl de l'équipement plutot que le warning lorsque la conf est activé
- Débug les selects unités, ils s'affichent dans la bonne case
- Ajout d'ajax pour que le select entrepot se mette à jour avec l'entrepot par défaut du produit lors de la sélection de celui-ci

Attention : bien penser à changer le num version car besoin de désactiver/réactiver le module.