### PR TITLE
PULLUP 3.4 : FIX table naming error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,12 +2,15 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- FIX: Add error message if no more available assets for this expedition *31/05/2021* - 3.5.1
+- NEW: automatically add all the assets contained in OF with the Add automatically select option *20/05/2021* - 3.5.0
 - FIX: missing en_US translations *22/04/2021* - 3.4.1
 
 ## Version 3.4.0 [2020-12-10]
 
 ### Added
 
+- NEW T2966 Affiche une seule ligne par lot au lieu de plusieurs - *24/05/2021* - 3.4.2
 - NEW T2476 Ventilation produits/équipement multicompany OFSOM
 
 ### Changed
@@ -17,4 +20,10 @@ All notable changes to this project will be documented in this file.
 - FIX : Manque filtre sur entrepots (getentities) sur écran réception standard
 - FIX : Manque filtre entité sur liste des équipements
 
+## Version 3.3.0 [2020-10-21]
 
+### Added
+
+### Changed
+
+- FIX error on table naming : the right table name is entity_thirdparty *29/06/2021* - 3.3.1

--- a/reception.php
+++ b/reception.php
@@ -1593,7 +1593,7 @@ function is_supplier_linked($entityId,$socid){
 	global $db;
 
 	$sql = "SELECT DISTINCT te.rowid FROM " . MAIN_DB_PREFIX . "societe AS s ";
-	$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "thirdparty_entity AS te ON s.rowid = te.fk_soc ";
+	$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "entity_thirdparty AS et ON s.rowid = et.fk_soc ";
 	$sql .= " WHERE te.entity=" . $entityId;
 	$sql .= " AND te.fk_soc =" . $socid;
 

--- a/reception.php
+++ b/reception.php
@@ -1594,8 +1594,8 @@ function is_supplier_linked($entityId,$socid){
 
 	$sql = "SELECT DISTINCT te.rowid FROM " . MAIN_DB_PREFIX . "societe AS s ";
 	$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "entity_thirdparty AS et ON s.rowid = et.fk_soc ";
-	$sql .= " WHERE te.entity=" . $entityId;
-	$sql .= " AND te.fk_soc =" . $socid;
+	$sql .= " WHERE et.entity=" . $entityId;
+	$sql .= " AND et.fk_soc =" . $socid;
 
 	$res = $db->query($sql);
 	if($res){

--- a/receptionofsom.php
+++ b/receptionofsom.php
@@ -1265,7 +1265,7 @@ function is_supplier_linked($entityId,$socid){
 	global $db;
 
 	$sql = "SELECT DISTINCT te.rowid FROM " . MAIN_DB_PREFIX . "societe AS s ";
-	$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "thirdparty_entity AS te ON s.rowid = te.fk_soc ";
+	$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "entity_thirdparty AS et ON s.rowid = et.fk_soc ";
 	$sql .= " WHERE te.entity=" . $entityId;
 	$sql .= " AND te.fk_soc =" . $socid;
 

--- a/receptionofsom.php
+++ b/receptionofsom.php
@@ -1266,8 +1266,8 @@ function is_supplier_linked($entityId,$socid){
 
 	$sql = "SELECT DISTINCT te.rowid FROM " . MAIN_DB_PREFIX . "societe AS s ";
 	$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "entity_thirdparty AS et ON s.rowid = et.fk_soc ";
-	$sql .= " WHERE te.entity=" . $entityId;
-	$sql .= " AND te.fk_soc =" . $socid;
+	$sql .= " WHERE et.entity=" . $entityId;
+	$sql .= " AND et.fk_soc =" . $socid;
 
 	$res = $db->query($sql);
 	return $db->num_rows($res) > 0;


### PR DESCRIPTION
# FIX

PULLUP du fix : Utilisation de la table thirdparty_entity dans le code : erreur de nommage, le nom correct de la table est entity_thirdparty, table créée par le module MultiCompany.

PR d'origine : https://github.com/ATM-Consulting/dolibarr_module_dispatch/pull/71

