### PR TITLE
FIX : Unused inherited functionality

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,4 +9,5 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- FIX remove unused inherited functionality that verify if each reception's line is ok *29/06/2021* - 3.3.2
 - FIX error on table naming : the right table name is entity_thirdparty *29/06/2021* - 3.3.1

--- a/core/modules/moddispatch.class.php
+++ b/core/modules/moddispatch.class.php
@@ -59,7 +59,7 @@ class moddispatch extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Module104970Desc";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '3.3.1';
+		$this->version = '3.3.2';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/reception.php
+++ b/reception.php
@@ -1075,7 +1075,6 @@ function _list_already_dispatched(&$commande) {
 				print '<td></td>';
 				print '<td>'.$langs->trans("Warehouse").'</td>';
 				print '<td>'.$langs->trans("Comment").'</td>';
-				if (! empty($conf->global->SUPPLIER_ORDER_USE_DISPATCH_STATUS) && (float) DOL_VERSION > 3.7) print '<td align="center" colspan="2">'.$langs->trans("Status").'</td>';
 				print "</tr>\n";
 
 				$var=false;
@@ -1111,55 +1110,6 @@ function _list_already_dispatched(&$commande) {
 
 					// Comment
 					print '<td>'.dol_trunc($objp->comment).'</td>';
-
-					// Status
-					if (! empty($conf->global->SUPPLIER_ORDER_USE_DISPATCH_STATUS) && (float) DOL_VERSION > 3.7)
-					{
-						print '<td align="right">';
-						$supplierorderdispatch->status = (empty($objp->status)?0:$objp->status);
-						//print $supplierorderdispatch->status;
-						print $supplierorderdispatch->getLibStatut(5);
-						print '</td>';
-
-						// Add button to check/uncheck disaptching
-						print '<td align="center">';
-						if ((empty($conf->global->MAIN_USE_ADVANCED_PERMS) && empty($user->rights->fournisseur->commande->receptionner))
-       					|| (! empty($conf->global->MAIN_USE_ADVANCED_PERMS) && empty($user->rights->fournisseur->commande_advance->check))
-							)
-						{
-							if (empty($objp->status))
-							{
-								print '<a class="button buttonRefused" href="#">'.$langs->trans("Approve").'</a>';
-								print '<a class="button buttonRefused" href="#">'.$langs->trans("Deny").'</a>';
-							}
-							else
-							{
-								print '<a class="button buttonRefused" href="#">'.$langs->trans("Disapprove").'</a>';
-								print '<a class="button buttonRefused" href="#">'.$langs->trans("Deny").'</a>';
-							}
-						}
-						else
-						{
-							$disabled='';
-							if ($commande->statut == 5) $disabled=1;
-							if (empty($objp->status))
-							{
-								print '<a class="button'.($disabled?' buttonRefused':'').'" href="'.$_SERVER["PHP_SELF"]."?id=".$id."&action=checkdispatchline&lineid=".$objp->dispatchlineid.'">'.$langs->trans("Approve").'</a>';
-								print '<a class="button'.($disabled?' buttonRefused':'').'" href="'.$_SERVER["PHP_SELF"]."?id=".$id."&action=denydispatchline&lineid=".$objp->dispatchlineid.'">'.$langs->trans("Deny").'</a>';
-							}
-							if ($objp->status == 1)
-							{
-								print '<a class="button'.($disabled?' buttonRefused':'').'" href="'.$_SERVER["PHP_SELF"]."?id=".$id."&action=uncheckdispatchline&lineid=".$objp->dispatchlineid.'">'.$langs->trans("Reinit").'</a>';
-								print '<a class="button'.($disabled?' buttonRefused':'').'" href="'.$_SERVER["PHP_SELF"]."?id=".$id."&action=denydispatchline&lineid=".$objp->dispatchlineid.'">'.$langs->trans("Deny").'</a>';
-							}
-							if ($objp->status == 2)
-							{
-								print '<a class="button'.($disabled?' buttonRefused':'').'" href="'.$_SERVER["PHP_SELF"]."?id=".$id."&action=uncheckdispatchline&lineid=".$objp->dispatchlineid.'">'.$langs->trans("Reinit").'</a>';
-								print '<a class="button'.($disabled?' buttonRefused':'').'" href="'.$_SERVER["PHP_SELF"]."?id=".$id."&action=checkdispatchline&lineid=".$objp->dispatchlineid.'">'.$langs->trans("Approve").'</a>';
-							}
-						}
-						print '</td>';
-					}
 
 					print "</tr>\n";
 

--- a/receptionofsom.php
+++ b/receptionofsom.php
@@ -500,9 +500,6 @@ function _list_shipments_untreated(&$shipments , $idCmdFourn){
 	}
 
 	print '<td></td>';
-	if (! empty($conf->global->SUPPLIER_ORDER_USE_DISPATCH_STATUS) && (float) DOL_VERSION > 3.7)
-		print '<td align="center" colspan="2">'.$langs->trans("Status").'</td>';
-
 	print "</tr>\n";
 	print "</table>\n";
 
@@ -562,9 +559,6 @@ function _list_shipments_treated(&$shipments , $idCmdFourn){
 		}
 
 		print '<td></td>';
-		if (! empty($conf->global->SUPPLIER_ORDER_USE_DISPATCH_STATUS) && (float) DOL_VERSION > 3.7)
-			print '<td align="center" colspan="2">'.$langs->trans("Status").'</td>';
-
 		print "</tr>\n";
 		print "</table>\n";
 


### PR DESCRIPTION
# FIX

Remove unused inherited functionality that verify if each reception's line is ok.
This feature has been inherited from Dolibarr standard when creating the reception screen of the Dispatch module.