### PR TITLE
3.5 fix ret dauphin expedition details

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ## Version 3.5 - 2021-07-06
 
+- FIX: expedition detaim - hide lot without units - 3.5.6 - *5/10/2021*
 - FIX: v14 compatibility - NOSCRFCHECK and selectMeasuringUnits - 3.5.5 - *15/09/2021*
 - FIX: v14 compatibility - setDateLivraison -> setDeliveryDate - 3.5.4 - *27/07/2021*
 - FIX : display quantity of shipped products on PDF *12/07/2021* - 3.5.3

--- a/core/modules/moddispatch.class.php
+++ b/core/modules/moddispatch.class.php
@@ -60,7 +60,7 @@ class moddispatch extends DolibarrModules
 		$this->description = "Module104970Desc";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '3.5.5';
+		$this->version = '3.5.6';
 
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);

--- a/script/interface.php
+++ b/script/interface.php
@@ -180,7 +180,7 @@ function _autocomplete_lot_number(&$PDOdb, $productid) {
 
 	$sql = "SELECT DISTINCT(lot_number),rowid, SUM(contenancereel_value) as qty, contenancereel_units as unit
 			FROM ".MAIN_DB_PREFIX.ATM_ASSET_NAME."
-			WHERE fk_product = ".$productid." GROUP BY lot_number,contenancereel_units,rowid";
+			WHERE fk_product = ".$productid." AND contenancereel_value != 0 GROUP BY lot_number,contenancereel_units,rowid";
 	$PDOdb->Execute($sql);
 
 	$TLotNumber = array('');

--- a/script/interface.php
+++ b/script/interface.php
@@ -180,7 +180,7 @@ function _autocomplete_lot_number(&$PDOdb, $productid) {
 
 	$sql = "SELECT DISTINCT(lot_number),rowid, SUM(contenancereel_value) as qty, contenancereel_units as unit
 			FROM ".MAIN_DB_PREFIX.ATM_ASSET_NAME."
-			WHERE fk_product = ".$productid." AND contenancereel_value != 0 GROUP BY lot_number,contenancereel_units,rowid";
+			WHERE fk_product = ".$productid." GROUP BY lot_number,contenancereel_units,rowid HAVING SUM(contenancereel_value) != 0";
 	$PDOdb->Execute($sql);
 
 	$TLotNumber = array('');


### PR DESCRIPTION
Détail d'une expédition : ne pas afficher dans le select les lots qui ont 0 unité.