### PR TITLE
FIX : Select serials without lot

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## Version 3.6 - 2021-12-03
+- FIX : il n'était pas possible d'ajouter un équipement avec numéro de série sans numéro de lot dans le détail d'une expédition - 3.6.3 - *27/01/2022*
 - FIX : les équipements n'apparaissaient pas dans le select des exped - 3.6.2 - *20/12/2021*
 - FIX : detail.php, la quantité ne s'affichait plus automatiquement, erreur de js (ligne commentée) - 3.6.1 - *07/12/2021*
 

--- a/core/modules/moddispatch.class.php
+++ b/core/modules/moddispatch.class.php
@@ -60,7 +60,7 @@ class moddispatch extends DolibarrModules
 		$this->description = "Module104970Desc";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '3.6.2';
+		$this->version = '3.6.3';
 
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);

--- a/langs/fr_FR/dispatch.lang
+++ b/langs/fr_FR/dispatch.lang
@@ -89,6 +89,7 @@ DISPATCH_ALLOW_DISPATCHING_EXISTING_ASSET=Permettre de réceptionner plusieurs f
 
 AllSerialNumbersAdded=Les numéros de série ont été enregistré automatiquement
 NoMoreAssetAvailable=Aucun équipement disponible pour ce numéro de lot
+AssetsWithoutLotNumber=Equipements sans numéro de lot
 
 # Expedition Card
 colDispatch=N° de série / lot

--- a/script/interface.php
+++ b/script/interface.php
@@ -116,8 +116,11 @@ function _autocomplete_asset(&$PDOdb, $lot_number, $productid, $expeditionID, $e
 			LEFT JOIN ".MAIN_DB_PREFIX."expeditiondet_asset eda ON (eda.fk_asset = a.rowid)
 			LEFT JOIN ".MAIN_DB_PREFIX."expeditiondet ed ON (ed.rowid = eda.fk_expeditiondet)
 			LEFT JOIN ".MAIN_DB_PREFIX."expedition e ON (e.rowid = ed.fk_expedition)
-			WHERE a.lot_number = '".$lot_number."'
-			AND a.fk_product = ".$productid;
+			WHERE a.fk_product = ".$productid;
+
+    // On ne prend pas en compte le numéro de lot dans la requête pour les équipements sans numéro de lot
+    if ($lot_number == -3) $sql .= " AND (a.lot_number IS NULL OR a.lot_number = '')";
+    else $sql .= " AND a.lot_number = '".$lot_number."'";
 
     if(empty($conf->global->DISPATCH_ALLOW_DISPATCHING_IGNORING_LOCALISATION)) {
         if(! empty($societe->id)) {
@@ -184,7 +187,7 @@ function _autocomplete_lot_number(&$PDOdb, $productid) {
 			WHERE fk_product = ".$productid." GROUP BY lot_number,contenancereel_units,rowid HAVING SUM(contenancereel_value) != 0";
 	$PDOdb->Execute($sql);
 
-	$TLotNumber = array('');
+	$TLotNumber = array('no_lot_number' => array('lot_number' => -3, 'label' => $langs->transnoentitiesnoconv('AssetsWithoutLotNumber')));
 	$PDOdb->Execute($sql);
 	$Tres = $PDOdb->Get_All();
 	foreach($Tres as $res){


### PR DESCRIPTION
# FIX

Il n'était pas possible d'ajouter un équipement avec numéro de série sans numéro de lot dans le détail d'une expédition.
Désormais, une option du select (Equipements sans numéro de lot) permet de charger tous les équipements avec numéro de série sans numéro de lot, dont l'entrepôt (saisi sur la fiche équipement) est le même que celui de la ligne d'expédition. 