### PR TITLE
Réalimenter équipement à la suppression de l'expédition

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## Version 3.7 - 2022-03-24
+- NEW : ajout conf "Réalimenter équipement à la suppression de l'expédition" pour la dissocier de "Retirer l'entrepot de l'équipement à la validation de l'expédition" - 3.7.0 - *21/03/2022*
 
 ## Version 3.6 - 2021-12-03
 - FIX : il n'était pas possible d'ajouter un équipement avec numéro de série sans numéro de lot dans le détail d'une expédition - 3.6.3 - *27/01/2022*

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -177,6 +177,15 @@
 
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
+	print '<td>'.$langs->trans('DISPATCH_RESET_ASSET_QTY_DELETE_SHIPMENT').'</td>';
+	print '<td align="center" width="20">&nbsp;</td>';
+	print '<td align="center" width="300">';
+	print ajax_constantonoff('DISPATCH_RESET_ASSET_QTY_DELETE_SHIPMENT');
+	print '</td></tr>';
+
+
+	$var=!$var;
+	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans('DISPATCH_SKIP_SERVICES').'</td>';
 	print '<td align="center" width="20">&nbsp;</td>';
 	print '<td align="center" width="300">';

--- a/core/modules/moddispatch.class.php
+++ b/core/modules/moddispatch.class.php
@@ -60,7 +60,7 @@ class moddispatch extends DolibarrModules
 		$this->description = "Module104970Desc";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '3.6.3';
+		$this->version = '3.7.0';
 
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);

--- a/core/triggers/interface_99_modDispatch_DispatchWorkflow.class.php
+++ b/core/triggers/interface_99_modDispatch_DispatchWorkflow.class.php
@@ -132,7 +132,7 @@ class InterfaceDispatchWorkflow
 				$TDetail = $dispatchDetail->LoadAllBy($PDOdb, array('fk_expeditiondet' => $line->id));
 
 				foreach($TDetail as &$detail) {
-					if(!empty($conf->global->DISPATCH_RESET_ASSET_WAREHOUSE_ON_SHIPMENT)
+					if(!empty($conf->global->DISPATCH_RESET_ASSET_QTY_DELETE_SHIPMENT)
 						&& (($conf->global->STOCK_CALCULATE_ON_SHIPMENT && $object->statut > 0)
 							|| ($conf->global->STOCK_CALCULATE_ON_SHIPMENT_CLOSE && $object->statut == 2))) {
 						$asset = new TAsset;
@@ -299,7 +299,7 @@ class InterfaceDispatchWorkflow
 
 		// Destockage Dolibarr déjà fait par à la validation de l'expédition, et impossible de ne destocker que l'équipement : on save sans rien déstocker
 		$asset->save($PDOdb, $user, $langs->trans("ShipmentValidatedInDolibarr",$numref), -$poids_destocke, false, 0, true);
-		
+
 		$fk_dol_moov = 0;
 		if ($conf->global->DISPATCH_LINK_ASSET_TO_STOCK_MOOV)
 		{

--- a/langs/fr_FR/dispatch.lang
+++ b/langs/fr_FR/dispatch.lang
@@ -131,3 +131,6 @@ ErrorUnableToFetchLine=Impossible de récupérer la ligne %d
 ErrorAtSaveObjectRecepDetail = Une erreur est survenue lors de l'enregistrement en base de données
 DISPATCH_ALLOW_DISPATCHING_IGNORING_LOCALISATION=Ignorer la localisation dans le détail des équipements sur une expédition
 DISPATCH_ALLOW_SENDING_SAME_PRODUCT_IN_SAME_EXP=Possibilité d'envoyer un numéro de série déjà présent dans une même expédition
+
+
+DISPATCH_RESET_ASSET_QTY_DELETE_SHIPMENT=Réalimenter équipement à la suppression de l'expédition


### PR DESCRIPTION
NEW : ajout conf "Réalimenter équipement à la suppression de l'expédition" pour la dissocier de "Retirer l'entrepot de l'équipement à la validation de l'expédition"

_TKDA021610_ 