### PR TITLE
FIX - Qty détails d'expédition

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Version 3.7 - 2022-03-24
 
+- FIX : DA023802 - La quantité lors de l'ajout dans le détails d'expédition est maintenant rempli avec la qty de la commande - 3.7.7 - *16/11/2023*
 - FIX : Fatal on reception - 3.7.6 - *30/08/2023*
 - FIX : Compat v17 (token) - 3.7.5 - *31/03/2023*
 - FIX : Missing icon - 3.7.4 - *22/07/2022*

--- a/core/modules/moddispatch.class.php
+++ b/core/modules/moddispatch.class.php
@@ -61,7 +61,7 @@ class moddispatch extends DolibarrModules
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
 
-		$this->version = '3.7.6';
+		$this->version = '3.7.7';
 
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);

--- a/detail.php
+++ b/detail.php
@@ -645,7 +645,7 @@ function printJSTabImportAddLine()
 				if(numserie && numserie.length > 0)
 				{
 					$('#quantity').show();
-					$('#quantity').val(optionselected.data('qty')).prop('max', optionselected.data('qty'));
+					//$('#quantity').val(optionselected.data('qty')).prop('max', optionselected.data('qty'));
 					$('#units_label').text($(this).data('unite_string'));
 					$('#newline_quantity').css({ visibility: 'visible' });
 				}


### PR DESCRIPTION
La quantité lors de l'ajout dans le détails d'expédition est maintenant rempli avec la qty de la commande 